### PR TITLE
Allow optional 'netbox_token' dcim parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The configuration file should have this form:
 ```
 [<DCIM1>]
 api_url = <api_url1>
+netbox_token = <netbox_api_token>           ; optional, NetBox API token
 
 [<DCIM2>]
 api_url = <api_url2>

--- a/rackops/dcim/base.py
+++ b/rackops/dcim/base.py
@@ -2,9 +2,10 @@ class DcimBase(object):
     # All dcims inherit this class
     # Defines the interface for dcims
     # and implements basic functionality
-    def __init__(self, identifier, is_rack, is_rack_unit, is_serial, api_url):
+    def __init__(self, identifier, is_rack, is_rack_unit, is_serial, dcim_params):
         self.identifier = identifier
-        self.api_url = api_url
+        self.dcim_params = dcim_params
+        self.api_url = self.dcim_params["api_url"]
         self.is_rack = is_rack
         self.is_rack_unit = is_rack_unit
         self.is_serial = is_serial

--- a/rackops/dcim/netbox.py
+++ b/rackops/dcim/netbox.py
@@ -7,8 +7,8 @@ import logging
 from rackops.dcim.base import DcimBase, DcimError
 
 class Netbox(DcimBase):
-    def __init__(self, identifier, is_rack, is_rack_unit, is_serial, api_url):
-        super(Netbox, self).__init__(identifier, is_rack, is_rack_unit, is_serial, api_url)
+    def __init__(self, identifier, is_rack, is_rack_unit, is_serial, dcim_params):
+        super(Netbox, self).__init__(identifier, is_rack, is_rack_unit, is_serial, dcim_params)
         self.info = self._retrieve_info()
 
     def _get_params(self):
@@ -35,7 +35,12 @@ class Netbox(DcimBase):
         return response["results"][0]["id"]
 
     def _get_headers(self):
-        return {"Accept": "application/json"}
+        headers = {"Accept": "application/json"}
+
+        token = self.dcim_params.get("netbox_token")
+        if token is not None:
+            headers.update({"Authorization": f"Token: {token}"})
+        return headers
 
     def _do_request(self, url, params):
         headers = self._get_headers()

--- a/rackops/rackops.py
+++ b/rackops/rackops.py
@@ -53,7 +53,7 @@ class Rackops:
         dcim = self.args.dcim.lower()
         dcim_params = self.config[dcim]
         try:
-            return self._dcim_table()[dcim](self.identifier, self.rack, self.rack_unit, self.serial, dcim_params['api_url'])
+            return self._dcim_table()[dcim](self.identifier, self.rack, self.rack_unit, self.serial, dcim_params)
         except KeyError:
             raise RackopsError("Not a valid dcim")
 


### PR DESCRIPTION
Add support for a new configuration option `netbox_token`. When used, it sets the required `Authorization` header for all NetBox API calls. This is mandatory for NetBox installations where anonymous read-access is disabled.